### PR TITLE
Bugfix: The AudioContext was not allowed to start.

### DIFF
--- a/examples/minimal.html
+++ b/examples/minimal.html
@@ -68,6 +68,7 @@
       // Speak when clicked
       const nodeSpeak = document.getElementById('speak');
       nodeSpeak.addEventListener('click', function () {
+        head.audioCtx.resume();
         try {
           const text = document.getElementById('text').value;
           if ( text ) {


### PR DESCRIPTION
The existing page was facing the error: The AudioContext was not allowed to start. It must be resumed (or created) after a user gesture on the page. This is because the audio context was initialized at the constructor call which was done before any user interaction. This is blocked by Chrome under the Web Audio API which is under autoplay. It says If an AudioContext is created before the document receives a user gesture, it will be created in the "suspended" state, and you will need to call resume() after the user gesture.. Hence, this fix re-initiates the audio context after the button was clicked.