### PR TITLE
Stream speak audio improvements

### DIFF
--- a/examples/azure-audio-streaming.html
+++ b/examples/azure-audio-streaming.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <title>Talking Head - Azure TTS Audio Streaming Example</title>
   <style>
-    body, html {
+    body,
+    html {
       width: 100%;
       height: 100%;
       max-width: 800px;
@@ -60,6 +62,7 @@
       border-radius: 4px;
       cursor: pointer;
     }
+
     #settings-button:hover {
       background: #444;
     }
@@ -73,15 +76,18 @@
       background-color: #333;
       padding: 10px;
       border-radius: 5px;
-      display: none; /* hidden by default */
+      display: none;
+      /* hidden by default */
       z-index: 998;
     }
+
     #settings-panel label {
       display: block;
       margin-top: 10px;
       font-weight: bold;
       font-size: 0.9rem;
     }
+
     #settings-panel input {
       width: calc(100% - 10px);
       padding: 5px;
@@ -104,6 +110,23 @@
       right: 10px;
       height: 40px;
       font-size: 20px;
+    }
+
+    #subtitles {
+      position: absolute;
+      bottom: 50px;
+      left: 10%;
+      right: 10%;
+      text-align: center;
+      font-size: 1.2em;
+      color: #ffffff;
+      text-shadow: 1px 1px 4px rgba(0, 0, 0, 0.7);
+      pointer-events: none;
+      z-index: 1000;
+      padding: 5px 10px;
+      border-radius: 5px;
+      background: rgba(0, 0, 0, 0.3);
+      display: none;
     }
   </style>
 
@@ -150,18 +173,24 @@
     let head;
     let microsoftSynthesizer = null;
 
-    function resetVisemeBuffer() {
+    function resetLipsyncBuffers() {
       visemesbuffer = {
         visemes: [],
         vtimes: [],
         vdurations: [],
       };
       prevViseme = null;
+      wordsbuffer = {
+        words: [],
+        wtimes: [],
+        wdurations: []
+      }
     }
 
     let visemesbuffer = null;
     let prevViseme = null;
-    resetVisemeBuffer();
+    let wordsbuffer = null;
+    resetLipsyncBuffers();
 
 
 
@@ -177,7 +206,7 @@
       azureTTSKey.value = sessionStorage.getItem('azureTTSKey') || '';
       azureRegion.value = sessionStorage.getItem('azureRegion') || '';
       [azureTTSKey, azureRegion].forEach(el => {
-        el.addEventListener('input', () => 
+        el.addEventListener('input', () =>
           sessionStorage.setItem(el.id === 'azure-key' ? 'azureTTSKey' : 'azureRegion', el.value.trim())
         );
       });
@@ -186,6 +215,7 @@
       head = new TalkingHead(nodeAvatar, {
         ttsEndpoint: "/gtts/",
         cameraView: "upper",
+        lipsyncLang: "en"
       });
 
       // Show "Loading..." by default
@@ -264,7 +294,7 @@
           microsoftSynthesizer = new window.SpeechSDK.SpeechSynthesizer(config, null);
 
           // Handle the synthesis results
-          microsoftSynthesizer.synthesizing = (s, e) =>{
+          microsoftSynthesizer.synthesizing = (s, e) => {
             head.streamAudio({
               audio: e.result.audioData,
               visemes: visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length),
@@ -275,29 +305,61 @@
 
           // Viseme handling
           microsoftSynthesizer.visemeReceived = (s, e) => {
-              const vtime = e.audioOffset / 10000;
-              const viseme = visemeMap[e.visemeId];
-              if (!head.isStreaming) return;
-              if (prevViseme) {
-                let vduration = vtime  - prevViseme.vtime;
-                if (vduration < 40) vduration = 40;
-                visemesbuffer.visemes.push(prevViseme.viseme);
-                visemesbuffer.vtimes.push(prevViseme.vtime);
-                visemesbuffer.vdurations.push(vduration);
-              }
-              prevViseme = { viseme, vtime };
+            const vtime = e.audioOffset / 10000;
+            const viseme = visemeMap[e.visemeId];
+            if (!head.isStreaming) return;
+            if (prevViseme) {
+              let vduration = vtime - prevViseme.vtime;
+              if (vduration < 40) vduration = 40;
+              visemesbuffer.visemes.push(prevViseme.viseme);
+              visemesbuffer.vtimes.push(prevViseme.vtime);
+              visemesbuffer.vdurations.push(vduration);
+            }
+            prevViseme = { viseme, vtime };
+          };
+
+          // Process word boundaries and punctuations
+          microsoftSynthesizer.wordBoundary = function (s, e) {
+            const word = e.text;
+            const time = e.audioOffset / 10000;
+            const duration = e.duration / 10000;
+
+            if (e.boundaryType === "PunctuationBoundary" && wordsbuffer.words.length) {
+              wordsbuffer.words[wordsbuffer.words.length - 1] += word;
+              wordsbuffer.wdurations[wordsbuffer.wdurations.length - 1] += duration;
+            } else if (e.boundaryType === "WordBoundary" || e.boundaryType === "PunctuationBoundary") {
+              wordsbuffer.words.push(word);
+              wordsbuffer.wtimes.push(time);
+              wordsbuffer.wdurations.push(duration);
+            }
           };
         }
 
         // Start stream speaking
         head.streamStart(
-          {sampleRate: 48000, mood: "happy"},
+          { sampleRate: 48000, mood: "happy", gain: 0.5 },
           () => {
             console.log("Audio playback started.");
+            const subtitlesElement = document.getElementById("subtitles");
+            subtitlesElement.textContent = "";
+            subtitlesElement.style.display = "none";
           },
           () => {
             console.log("Audio playback ended.");
-          });
+            const subtitlesElement = document.getElementById("subtitles");
+            const displayDuration = Math.max(2000, subtitlesElement.textContent.length * 50);
+            setTimeout(() => {
+              subtitlesElement.textContent = "";
+              subtitlesElement.style.display = "none";
+            }, displayDuration);
+          },
+          (subtitleText) => {
+            console.log("subtitleText: ", subtitleText);
+            const subtitlesElement = document.getElementById("subtitles");
+            subtitlesElement.textContent += subtitleText;
+            subtitlesElement.style.display = subtitlesElement.textContent ? "block" : "none";
+          }
+        );
 
         // Perform TTS
         microsoftSynthesizer.speakSsmlAsync(
@@ -306,34 +368,37 @@
             if (result.reason === window.SpeechSDK.ResultReason.SynthesizingAudioCompleted) {
 
               if (prevViseme) {
-                  // Final viseme duration guess
-                  const finalDuration = 100; 
-                  // Add to visemesbuffer
-                  visemesbuffer.visemes.push(prevViseme.viseme);
-                  visemesbuffer.vtimes.push(prevViseme.vtime);
-                  visemesbuffer.vdurations.push(finalDuration);
-                  // Now clear the last viseme
-                  prevViseme = null;
+                // Final viseme duration guess
+                const finalDuration = 100;
+                // Add to visemesbuffer
+                visemesbuffer.visemes.push(prevViseme.viseme);
+                visemesbuffer.vtimes.push(prevViseme.vtime);
+                visemesbuffer.vdurations.push(finalDuration);
+                // Now clear the last viseme
+                prevViseme = null;
               }
-                // stream any remaining visemes
-                if (visemesbuffer.visemes.length) {
-                  const speak = {
-                    audio: null,
-                    visemes: visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length),
-                    vtimes: visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length),
-                    vdurations: visemesbuffer.vdurations.splice(0, visemesbuffer.vdurations.length),
-                  }
-                 head.streamAudio(speak);
+              // stream any remaining visemes
+              if (visemesbuffer.visemes.length) {
+                const speak = {
+                  audio: null,
+                  visemes: visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length),
+                  vtimes: visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length),
+                  vdurations: visemesbuffer.vdurations.splice(0, visemesbuffer.vdurations.length),
+                  words: wordsbuffer.words.splice(0, wordsbuffer.words.length),
+                  wtimes: wordsbuffer.wtimes.splice(0, wordsbuffer.wtimes.length),
+                  wdurations: wordsbuffer.wdurations.splice(0, wordsbuffer.wdurations.length)
                 }
-                
-                head.streamNotifyEnd();
-                resetVisemeBuffer();
-                console.log("Speech synthesis completed.");
+                head.streamAudio(speak);
+              }
+
+              head.streamNotifyEnd();
+              resetLipsyncBuffers();
+              console.log("Speech synthesis completed.");
             }
           },
           (error) => {
             console.error("Azure speech synthesis error:", error);
-            resetVisemeBuffer();
+            resetLipsyncBuffers();
           }
         );
       }
@@ -349,6 +414,7 @@
 <body>
   <!-- 3D Avatar -->
   <div id="avatar"></div>
+  <div id="subtitles"></div>
 
   <!-- Controls at the top -->
   <div id="controls">
@@ -369,4 +435,5 @@
   <!-- Loading or error display -->
   <div id="loading"></div>
 </body>
+
 </html>

--- a/examples/azure-audio-streaming.html
+++ b/examples/azure-audio-streaming.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Talking Head - Azure Audio Streaming Example</title>
+  <style>
+    body, html {
+      width: 100%;
+      height: 100%;
+      max-width: 800px;
+      margin: auto;
+      position: relative;
+      background-color: #202020;
+      color: white;
+      font-family: Arial, sans-serif;
+      overflow: hidden;
+    }
+
+    /* The main 3D avatar container */
+    #avatar {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    /* Controls container at top */
+    #controls {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      right: 10px;
+      height: 40px;
+    }
+
+    #text {
+      flex: 1;
+      font-size: 20px;
+      height: 100%;
+      padding: 5px;
+      box-sizing: border-box;
+    }
+
+    #speak {
+      width: 100px;
+      height: 100%;
+      font-size: 16px;
+      cursor: pointer;
+    }
+
+    /* Settings toggle button */
+    #settings-button {
+      width: 80px;
+      height: 100%;
+      font-size: 16px;
+      background: #333;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    #settings-button:hover {
+      background: #444;
+    }
+
+    /* Collapsible Settings Panel */
+    #settings-panel {
+      position: absolute;
+      top: 60px;
+      right: 10px;
+      width: 220px;
+      background-color: #333;
+      padding: 10px;
+      border-radius: 5px;
+      display: none; /* hidden by default */
+      z-index: 998;
+    }
+    #settings-panel label {
+      display: block;
+      margin-top: 10px;
+      font-weight: bold;
+      font-size: 0.9rem;
+    }
+    #settings-panel input {
+      width: calc(100% - 10px);
+      padding: 5px;
+      margin-top: 5px;
+      font-size: 0.9rem;
+      box-sizing: border-box;
+    }
+
+    /* When the body gets a class "show-settings", show the panel */
+    body.show-settings #settings-panel {
+      display: block;
+    }
+
+    /* Loading text at bottom-left */
+    #loading {
+      display: block;
+      position: absolute;
+      bottom: 10px;
+      left: 10px;
+      right: 10px;
+      height: 40px;
+      font-size: 20px;
+    }
+  </style>
+
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js/+esm",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/",
+        "talkinghead": "../modules/talkinghead.mjs"
+      }
+    }
+  </script>
+
+  <script
+    src="https://cdn.jsdelivr.net/npm/microsoft-cognitiveservices-speech-sdk@latest/distrib/browser/microsoft.cognitiveservices.speech.sdk.bundle-min.js"></script>
+
+  <script type="module">
+    import { TalkingHead } from "talkinghead";
+
+    const visemeMap = [
+      /* 0  */ "sil",            // Silence
+      /* 1  */ "aa",             // æ, ə, ʌ
+      /* 2  */ "aa",             // ɑ
+      /* 3  */ "O",              // ɔ
+      /* 4  */ "E",              // ɛ, ʊ
+      /* 5  */ "RR",              // ɝ
+      /* 6  */ "I",              // j, i, ɪ
+      /* 7  */ "U",              // w, u
+      /* 8  */ "O",              // o
+      /* 9  */ "O",             // aʊ
+      /* 10 */ "O",              // ɔɪ
+      /* 11 */ "I",              // aɪ
+      /* 12 */ "kk",             // h
+      /* 13 */ "RR",             // ɹ
+      /* 14 */ "nn",             // l
+      /* 15 */ "SS",             // s, z
+      /* 16 */ "CH",             // ʃ, tʃ, dʒ, ʒ
+      /* 17 */ "TH",             // ð
+      /* 18 */ "FF",             // f, v
+      /* 19 */ "DD",             // d, t, n, θ
+      /* 20 */ "kk",             // k, g, ŋ
+      /* 21 */ "PP"              // p, b, m
+    ];
+    let head;
+    let microsoftSynthesizer = null;
+
+    function resetVisemeBuffer() {
+      visemesbuffer = {
+        visemes: [],
+        vtimes: [],
+        vdurations: [],
+      };
+      prevViseme = null;
+    }
+
+    let visemesbuffer = null;
+    let prevViseme = null;
+    resetVisemeBuffer();
+
+
+
+    document.addEventListener('DOMContentLoaded', async () => {
+      console.log("Loading Talking Head...");
+      const nodeAvatar = document.getElementById('avatar');
+      const nodeSpeak = document.getElementById('speak');
+      const nodeLoading = document.getElementById('loading');
+      const azureRegion = document.getElementById('azure-region');
+      const azureTTSKey = document.getElementById('azure-key');
+      const settingsButton = document.getElementById('settings-button');
+
+      azureTTSKey.value = sessionStorage.getItem('azureTTSKey') || '';
+      azureRegion.value = sessionStorage.getItem('azureRegion') || '';
+      [azureTTSKey, azureRegion].forEach(el => {
+        el.addEventListener('input', () => 
+          sessionStorage.setItem(el.id === 'azure-key' ? 'azureTTSKey' : 'azureRegion', el.value.trim())
+        );
+      });
+
+      // Initialize TalkingHead
+      head = new TalkingHead(nodeAvatar, {
+        ttsEndpoint: "/gtts/",
+        cameraView: "upper",
+      });
+
+      // Show "Loading..." by default
+      nodeLoading.textContent = "Loading...";
+
+      // Load the avatar
+      try {
+        await head.showAvatar(
+          {
+            url: 'https://models.readyplayer.me/64bfa15f0e72c63d7c3934a6.glb?morphTargets=ARKit,Oculus+Visemes,mouthOpen,mouthSmile,eyesClosed,eyesLookUp,eyesLookDown&textureSizeLimit=1024&textureFormat=png',
+            body: 'F',
+          },
+          (ev) => {
+            if (ev.lengthComputable) {
+              const percent = Math.round((ev.loaded / ev.total) * 100);
+              nodeLoading.textContent = `Loading ${percent}%`;
+            } else {
+              nodeLoading.textContent = `Loading... ${Math.round(ev.loaded / 1024)} KB`;
+            }
+          }
+        );
+        // Hide the loading element once fully loaded
+        nodeLoading.style.display = 'none';
+      } catch (error) {
+        console.error("Error loading avatar:", error);
+        nodeLoading.textContent = "Failed to load avatar.";
+      }
+
+      // Handle speech button click
+      nodeSpeak.addEventListener('click', () => {
+        const text = document.getElementById('text').value.trim();
+        if (text) {
+          const ssml = textToSSML(text);
+          azureSpeak(ssml);
+        }
+      });
+
+      // Pause/resume animation on visibility change
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") {
+          head.start();
+        } else {
+          head.stop();
+        }
+      });
+
+      // Convert input text to SSML
+      function textToSSML(text) {
+        return `
+          <speak version="1.0" xmlns:mstts="http://www.w3.org/2001/mstts" xml:lang="en-US">
+            <voice name="en-US-EmmaNeural">
+              <mstts:viseme type="FacialExpression" />
+              ${text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')}
+            </voice>
+          </speak>`;
+      }
+
+      // Perform Azure TTS
+      function azureSpeak(ssml) {
+        if (!microsoftSynthesizer) {
+          // Retrieve config from input fields
+          const regionValue = azureRegion.value.trim();
+          const keyValue = azureTTSKey.value.trim();
+          if (!regionValue || !keyValue) {
+            console.error("Azure TTS region/key missing!");
+            alert("Please enter your Azure TTS key and region in the settings panel.");
+            return;
+          }
+
+          const config = window.SpeechSDK.SpeechConfig.fromSubscription(keyValue, regionValue);
+          config.speechSynthesisOutputFormat =
+            window.SpeechSDK.SpeechSynthesisOutputFormat.Raw48Khz16BitMonoPcm;
+          microsoftSynthesizer = new window.SpeechSDK.SpeechSynthesizer(config, null);
+
+          // Handle the synthesis results
+          microsoftSynthesizer.synthesizing = (s, e) =>{
+            head.sspeakAudio({
+              audio: e.result.audioData,
+              visemes: visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length),
+              vtimes: visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length),
+              vdurations: visemesbuffer.vdurations.splice(0, visemesbuffer.vdurations.length),
+            });
+          };
+
+          // Viseme handling
+          microsoftSynthesizer.visemeReceived = (s, e) => {
+              const vtime = e.audioOffset / 10000;
+              const viseme = visemeMap[e.visemeId];
+              if (!head.isStreaming) return;
+              if (prevViseme) {
+                let vduration = vtime  - prevViseme.vtime;
+                if (vduration < 40) vduration = 40;
+                visemesbuffer.visemes.push(prevViseme.viseme);
+                visemesbuffer.vtimes.push(prevViseme.vtime);
+                visemesbuffer.vdurations.push(vduration);
+              }
+              prevViseme = { viseme, vtime };
+          };
+        }
+
+        // Start stream speaking
+        head.sstartSpeaking(
+          {mood: "happy"},
+          () => {
+            console.log("Audio playback started.");
+          },
+          () => {
+            console.log("Audio playback ended.");
+          });
+
+        // Perform TTS
+        microsoftSynthesizer.speakSsmlAsync(
+          ssml,
+          (result) => {
+            if (result.reason === window.SpeechSDK.ResultReason.SynthesizingAudioCompleted) {
+
+              if (prevViseme) {
+                  // Final viseme duration guess
+                  const finalDuration = 100; 
+                  // Add to visemesbuffer
+                  visemesbuffer.visemes.push(prevViseme.viseme);
+                  visemesbuffer.vtimes.push(prevViseme.vtime);
+                  visemesbuffer.vdurations.push(finalDuration);
+                  // Now clear the last viseme
+                  prevViseme = null;
+              }
+                // stream any remaining visemes
+                if (visemesbuffer.visemes.length) {
+                  const speak = {
+                    audio: null,
+                    visemes: visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length),
+                    vtimes: visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length),
+                    vdurations: visemesbuffer.vdurations.splice(0, visemesbuffer.vdurations.length),
+                  }
+                 head.sspeakAudio(speak);
+                }
+                
+                head.notifyStreamEnd();
+                resetVisemeBuffer();
+                console.log("Speech synthesis completed.");
+            }
+          },
+          (error) => {
+            console.error("Azure speech synthesis error:", error);
+            resetVisemeBuffer();
+          }
+        );
+      }
+
+      // Toggle the settings panel on/off
+      settingsButton.addEventListener('click', () => {
+        document.body.classList.toggle('show-settings');
+      });
+    });
+  </script>
+</head>
+
+<body>
+  <!-- 3D Avatar -->
+  <div id="avatar"></div>
+
+  <!-- Controls at the top -->
+  <div id="controls">
+    <input id="text" type="text" value="Hello, how are you?" />
+    <button id="speak">Speak</button>
+    <button id="settings-button">Settings</button>
+  </div>
+
+  <!-- Collapsible Settings Panel -->
+  <div id="settings-panel">
+    <label for="azure-key">Azure Key</label>
+    <input id="azure-key" type="text" aria-label="Azure key" placeholder="Enter Azure Key">
+
+    <label for="azure-region">Azure Region</label>
+    <input id="azure-region" type="text" aria-label="Azure region" placeholder="Enter Azure Region">
+  </div>
+
+  <!-- Loading or error display -->
+  <div id="loading"></div>
+</body>
+</html>

--- a/examples/azure-audio-streaming.html
+++ b/examples/azure-audio-streaming.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>Talking Head - Azure Audio Streaming Example</title>
+  <title>Talking Head - Azure TTS Audio Streaming Example</title>
   <style>
     body, html {
       width: 100%;
@@ -265,7 +265,7 @@
 
           // Handle the synthesis results
           microsoftSynthesizer.synthesizing = (s, e) =>{
-            head.sspeakAudio({
+            head.streamAudio({
               audio: e.result.audioData,
               visemes: visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length),
               vtimes: visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length),
@@ -290,8 +290,8 @@
         }
 
         // Start stream speaking
-        head.sstartSpeaking(
-          {mood: "happy"},
+        head.streamStart(
+          {sampleRate: 48000, mood: "happy"},
           () => {
             console.log("Audio playback started.");
           },
@@ -323,10 +323,10 @@
                     vtimes: visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length),
                     vdurations: visemesbuffer.vdurations.splice(0, visemesbuffer.vdurations.length),
                   }
-                 head.sspeakAudio(speak);
+                 head.streamAudio(speak);
                 }
                 
-                head.notifyStreamEnd();
+                head.streamNotifyEnd();
                 resetVisemeBuffer();
                 console.log("Speech synthesis completed.");
             }

--- a/examples/azure-audio-streaming.html
+++ b/examples/azure-audio-streaming.html
@@ -128,6 +128,22 @@
       background: rgba(0, 0, 0, 0.3);
       display: none;
     }
+
+    #lipsync-type {
+      text-align: left;
+    }
+
+    #lipsync-type label {
+      display: inline-flex;
+      align-items: center;
+      margin-right: 1rem;
+    }
+
+    #lipsync-type label input[type="radio"] {
+      display: inline-block !important;
+      width: auto !important;
+      margin-right: 0.3rem;
+    }
   </style>
 
   <script type="importmap">
@@ -170,6 +186,64 @@
       /* 20 */ "kk",             // k, g, ŋ
       /* 21 */ "PP"              // p, b, m
     ];
+
+    const AzureBlendshapeMap = [
+      /* 0  */ "eyeBlinkLeft",
+      /* 1  */ "eyeLookDownLeft",
+      /* 2  */ "eyeLookInLeft",
+      /* 3  */ "eyeLookOutLeft",
+      /* 4  */ "eyeLookUpLeft",
+      /* 5  */ "eyeSquintLeft",
+      /* 6  */ "eyeWideLeft",
+      /* 7  */ "eyeBlinkRight",
+      /* 8  */ "eyeLookDownRight",
+      /* 9  */ "eyeLookInRight",
+      /* 10 */ "eyeLookOutRight",
+      /* 11 */ "eyeLookUpRight",
+      /* 12 */ "eyeSquintRight",
+      /* 13 */ "eyeWideRight",
+      /* 14 */ "jawForward",
+      /* 15 */ "jawLeft",
+      /* 16 */ "jawRight",
+      /* 17 */ "jawOpen",
+      /* 18 */ "mouthClose",
+      /* 19 */ "mouthFunnel",
+      /* 20 */ "mouthPucker",
+      /* 21 */ "mouthLeft",
+      /* 22 */ "mouthRight",
+      /* 23 */ "mouthSmileLeft",
+      /* 24 */ "mouthSmileRight",
+      /* 25 */ "mouthFrownLeft",
+      /* 26 */ "mouthFrownRight",
+      /* 27 */ "mouthDimpleLeft",
+      /* 28 */ "mouthDimpleRight",
+      /* 29 */ "mouthStretchLeft",
+      /* 30 */ "mouthStretchRight",
+      /* 31 */ "mouthRollLower",
+      /* 32 */ "mouthRollUpper",
+      /* 33 */ "mouthShrugLower",
+      /* 34 */ "mouthShrugUpper",
+      /* 35 */ "mouthPressLeft",
+      /* 36 */ "mouthPressRight",
+      /* 37 */ "mouthLowerDownLeft",
+      /* 38 */ "mouthLowerDownRight",
+      /* 39 */ "mouthUpperUpLeft",
+      /* 40 */ "mouthUpperUpRight",
+      /* 41 */ "browDownLeft",
+      /* 42 */ "browDownRight",
+      /* 43 */ "browInnerUp",
+      /* 44 */ "browOuterUpLeft",
+      /* 45 */ "browOuterUpRight",
+      /* 46 */ "cheekPuff",
+      /* 47 */ "cheekSquintLeft",
+      /* 48 */ "cheekSquintRight",
+      /* 49 */ "noseSneerLeft",
+      /* 50 */ "noseSneerRight",
+      /* 51 */ "tongueOut",
+      /* 52 */ "headRotateZ",
+      /* 53 */ // "leftEyeRoll", // Not supported
+      /* 54 */ // "rightEyeRoll" // Not supported
+    ];
     let head;
     let microsoftSynthesizer = null;
 
@@ -184,15 +258,21 @@
         words: [],
         wtimes: [],
         wdurations: []
-      }
+      };
+      azureBlendShapes = {
+        frames: [],
+        sbuffer: [],
+        orderBuffer: {}
+      };
+
     }
 
     let visemesbuffer = null;
     let prevViseme = null;
     let wordsbuffer = null;
+    let azureBlendShapes = null;
+    let lipsyncType = "visemes";
     resetLipsyncBuffers();
-
-
 
     document.addEventListener('DOMContentLoaded', async () => {
       console.log("Loading Talking Head...");
@@ -247,6 +327,7 @@
       // Handle speech button click
       nodeSpeak.addEventListener('click', () => {
         const text = document.getElementById('text').value.trim();
+        lipsyncType = document.querySelector('input[name="lipsync_type"]:checked').value;
         if (text) {
           const ssml = textToSSML(text);
           azureSpeak(ssml);
@@ -295,27 +376,73 @@
 
           // Handle the synthesis results
           microsoftSynthesizer.synthesizing = (s, e) => {
-            head.streamAudio({
-              audio: e.result.audioData,
-              visemes: visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length),
-              vtimes: visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length),
-              vdurations: visemesbuffer.vdurations.splice(0, visemesbuffer.vdurations.length),
-            });
+
+            switch (lipsyncType) {
+              case "blendshapes":
+                head.streamAudio({
+                  audio: e.result.audioData,
+                  anims: azureBlendShapes?.sbuffer.splice(0, azureBlendShapes?.sbuffer.length)
+                });
+                break;
+              case "visemes":
+                head.streamAudio({
+                  audio: e.result.audioData,
+                  visemes: visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length),
+                  vtimes: visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length),
+                  vdurations: visemesbuffer.vdurations.splice(0, visemesbuffer.vdurations.length),
+                });
+                break;
+              case "words":
+                head.streamAudio({
+                  audio: e.result.audioData,
+                  words: wordsbuffer.words.splice(0, wordsbuffer.words.length),
+                  wtimes: wordsbuffer.wtimes.splice(0, wordsbuffer.wtimes.length),
+                  wdurations: wordsbuffer.wdurations.splice(0, wordsbuffer.wdurations.length)
+                });
+                break;
+              default:
+                console.error(`Unknown animation mode: ${lipsyncType}`);
+            }
           };
 
           // Viseme handling
           microsoftSynthesizer.visemeReceived = (s, e) => {
-            const vtime = e.audioOffset / 10000;
-            const viseme = visemeMap[e.visemeId];
-            if (!head.isStreaming) return;
-            if (prevViseme) {
-              let vduration = vtime - prevViseme.vtime;
-              if (vduration < 40) vduration = 40;
-              visemesbuffer.visemes.push(prevViseme.viseme);
-              visemesbuffer.vtimes.push(prevViseme.vtime);
-              visemesbuffer.vdurations.push(vduration);
+            if (lipsyncType === "visemes") {
+              const vtime = e.audioOffset / 10000;
+              const viseme = visemeMap[e.visemeId];
+              if (!head.isStreaming) return;
+              if (prevViseme) {
+                let vduration = vtime - prevViseme.vtime;
+                if (vduration < 40) vduration = 40;
+                visemesbuffer.visemes.push(prevViseme.viseme);
+                visemesbuffer.vtimes.push(prevViseme.vtime);
+                visemesbuffer.vdurations.push(vduration);
+              }
+              prevViseme = { viseme, vtime };
+
+            } else if (lipsyncType === "blendshapes") {
+              let animation = null;
+              if (e?.animation && e.animation.trim() !== "") {
+                try {
+                  animation = JSON.parse(e.animation);
+                } catch (error) {
+                  console.error("Error parsing animation blendshapes:", error);
+                  return;
+                }
+              }
+              if (!animation) return;
+              const vs = {};
+              AzureBlendshapeMap.forEach((mtName, i) => {
+                vs[mtName] = animation.BlendShapes.map(frame => frame[i]);
+              });
+
+              azureBlendShapes.sbuffer.push({
+                name: "blendshapes",
+                delay: animation.FrameIndex * 1000 / 60,
+                dt: Array.from({ length: animation.BlendShapes.length }, () => 1000 / 60),
+                vs: vs,
+              });
             }
-            prevViseme = { viseme, vtime };
           };
 
           // Process word boundaries and punctuations
@@ -337,7 +464,7 @@
 
         // Start stream speaking
         head.streamStart(
-          { sampleRate: 48000, mood: "happy", gain: 0.5 },
+          { sampleRate: 48000, mood: "happy", gain: 0.5, lipsyncType: lipsyncType },
           () => {
             console.log("Audio playback started.");
             const subtitlesElement = document.getElementById("subtitles");
@@ -366,8 +493,7 @@
           ssml,
           (result) => {
             if (result.reason === window.SpeechSDK.ResultReason.SynthesizingAudioCompleted) {
-
-              if (prevViseme) {
+              if (lipsyncType === "visemes" && prevViseme) {
                 // Final viseme duration guess
                 const finalDuration = 100;
                 // Add to visemesbuffer
@@ -377,17 +503,25 @@
                 // Now clear the last viseme
                 prevViseme = null;
               }
-              // stream any remaining visemes
-              if (visemesbuffer.visemes.length) {
-                const speak = {
-                  audio: null,
-                  visemes: visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length),
-                  vtimes: visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length),
-                  vdurations: visemesbuffer.vdurations.splice(0, visemesbuffer.vdurations.length),
-                  words: wordsbuffer.words.splice(0, wordsbuffer.words.length),
-                  wtimes: wordsbuffer.wtimes.splice(0, wordsbuffer.wtimes.length),
-                  wdurations: wordsbuffer.wdurations.splice(0, wordsbuffer.wdurations.length)
-                }
+              let speak = {};
+              // stream any remaining visemes, blendshapes, or words
+              if (lipsyncType === "visemes" && visemesbuffer.visemes.length) {
+                speak.visemes = visemesbuffer.visemes.splice(0, visemesbuffer.visemes.length);
+                speak.vtimes = visemesbuffer.vtimes.splice(0, visemesbuffer.vtimes.length);
+                speak.vdurations = visemesbuffer.vdurations.splice(0, visemesbuffer.vdurations.length);
+              }
+              if (lipsyncType === "blendshapes") {
+                speak.anims = azureBlendShapes?.sbuffer.splice(0, azureBlendShapes?.sbuffer.length);
+              }
+
+              // stream words always for subtitles
+              speak.words = wordsbuffer.words.splice(0, wordsbuffer.words.length);
+              speak.wtimes = wordsbuffer.wtimes.splice(0, wordsbuffer.wtimes.length);
+              speak.wdurations = wordsbuffer.wdurations.splice(0, wordsbuffer.wdurations.length);
+
+              if (speak.visemes || speak.words || speak.anims) {
+                // If we have any visemes, words, or blendshapes left, stream them
+                speak.audio = null;
                 head.streamAudio(speak);
               }
 
@@ -430,6 +564,22 @@
 
     <label for="azure-region">Azure Region</label>
     <input id="azure-region" type="text" aria-label="Azure region" placeholder="Enter Azure Region">
+    <br>
+    <fieldset id="lipsync-type">
+      <legend>Lip-sync Data Type</legend>
+      <label>
+        <input type="radio" name="lipsync_type" value="visemes" checked>
+        Visemes
+      </label>
+      <label>
+        <input type="radio" name="lipsync_type" value="words">
+        Words
+      </label>
+      <label>
+        <input type="radio" name="lipsync_type" value="blendshapes">
+        Blend shapes
+      </label>
+    </fieldset>
   </div>
 
   <!-- Loading or error display -->

--- a/modules/playback-worklet.js
+++ b/modules/playback-worklet.js
@@ -1,0 +1,73 @@
+class PlaybackWorklet extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.port.onmessage = this.handleMessage.bind(this);
+    this.port.on;
+    this.buffer = [];
+    this.framesOfSilence = -1;    // -1 = haven't started receiving data yet
+    this.silenceThreshold = 1000;  // e.g. ~1000 blocks of silence
+    this.noMoreData = false;          // flag indicating no more audio data is coming
+  }
+
+  handleMessage(event) {
+    if (!event.data) {
+      this.buffer = [];
+      return;
+    }
+
+    if (event.data.type === 'no-more-data') {
+      // The main thread says no more audio chunks will arrive
+      this.noMoreData = true;
+      return;
+    }
+
+    this.buffer.push(...event.data);
+  }
+
+  process(inputs, outputs, parameters) {
+    const output = outputs[0];
+    const channel = output[0];
+
+    // Detect start of audio
+    if(this.buffer.length > 0 && this.framesOfSilence === -1) {
+      this.framesOfSilence = 0;
+      this.port.postMessage({ type: 'playback-started' });
+    }
+    
+    // Silence tracker
+    if (this.buffer.length > 0) {
+      this.framesOfSilence = 0;
+    }
+    else if (this.framesOfSilence !== -1) {
+      this.framesOfSilence++;
+    }
+    
+    // Play audio
+    if (this.buffer.length > channel.length) {
+      const toProcess = this.buffer.splice(0, channel.length);
+      channel.set(toProcess.map((v) => v / 32768));
+    } else {
+      // console.log("buffer.length", this.buffer.length, "channel.length", channel.length, Date.now());
+      channel.set(this.buffer.map((v) => v / 32768));
+      this.buffer = [];
+    }
+
+    // If noMoreData was set AND we have fully drained the buffer => end
+    if (this.noMoreData && this.buffer.length === 0) {
+      this.port.postMessage({ type: 'playback-ended' });
+      console.warn('[PlaybackWorklet] ended after noMoreData + buffer consumed');
+      return false;
+    }
+
+    // Fallback silence detection logic
+    if (this.framesOfSilence > this.silenceThreshold) {
+      this.port.postMessage({ type: 'playback-ended' });
+      console.warn('playback-ended signal detected after silence');
+      this.framesOfSilence = -1; // Reset to avoid sending multiple signals
+      return false;
+    }
+    return true;
+  }
+}
+
+registerProcessor("playback-worklet", PlaybackWorklet);

--- a/modules/playback-worklet.js
+++ b/modules/playback-worklet.js
@@ -2,70 +2,129 @@ class PlaybackWorklet extends AudioWorkletProcessor {
   constructor() {
     super();
     this.port.onmessage = this.handleMessage.bind(this);
-    this.buffer = [];
-    this.framesOfSilence = -1;    // -1 = haven't started receiving data yet
-    this.silenceThreshold = 1000;  // e.g. ~1000 blocks of silence
-    this.noMoreData = false;          // flag indicating no more audio data is coming
+    this.bufferQueue = [];        // Queue to hold incoming ArrayBuffers
+    this.currentChunk = null;     // Int16Array view of the ArrayBuffer currently being processed
+    this.currentChunkOffset = 0;  // Index offset within the currentChunk
+
+    this.playbackStartedSignalled = false; // Flag to indicate if playback has started
+    this.noMoreData = false;          // Flag indicating the main thread won't send more audio data
+    this.playedAnyData = false;       // Tracks if any audio data has actually been processed/played
+
+    // Silence Detection
+    this.silenceFramesCount = 0;      // Counts consecutive process() calls with no data available from queue
+    const silenceDurationSeconds = 1.0; // Duration to consider as silence
+    this.silenceThresholdBlocks = Math.ceil((sampleRate * silenceDurationSeconds) / 128);
   }
 
   handleMessage(event) {
-    if (!event.data) {
-      this.buffer = [];
-      return;
-    }
+    const data = event.data;
 
-    if (event.data.type === "no-more-data") {
-      // The main thread says no more audio chunks will arrive
+      // The main thread signaled no more audio data will come.
+    if (data?.type === "no-more-data") {
       this.noMoreData = true;
       return;
     }
 
-    this.buffer.push(...event.data);
+    if (data instanceof ArrayBuffer) {
+       this.bufferQueue.push(data);
+       this.silenceFramesCount = 0; // Reset silence counter
+    } else if (data instanceof Int16Array) {
+        const bufferCopy = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+        this.bufferQueue.push(bufferCopy);
+        this.silenceFramesCount = 0; // Reset silence counter
+     } else {
+         console.error("Unsupported data type received.");
+     }
   }
 
   process(inputs, outputs, parameters) {
-    const output = outputs[0];
-    const channel = output[0];
+    // Assume mono output channel
+    const outputChannel = outputs[0]?.[0];
 
-    // Detect start of audio
-    if(this.buffer.length > 0 && this.framesOfSilence === -1) {
-      this.framesOfSilence = 0;
-      this.port.postMessage({ type: "playback-started" });
-    }
-    
-    // Silence tracker
-    if (this.buffer.length > 0) {
-      this.framesOfSilence = 0;
-    }
-    else if (this.framesOfSilence !== -1) {
-      this.framesOfSilence++;
-    }
-    
-    // Play audio
-    if (this.buffer.length > channel.length) {
-      const toProcess = this.buffer.splice(0, channel.length);
-      channel.set(toProcess.map((v) => v / 32768));
-    } else {
-      // console.log("buffer.length", this.buffer.length, "channel.length", channel.length, Date.now());
-      channel.set(this.buffer.map((v) => v / 32768));
-      this.buffer = [];
+    // If no output channel exists (e.g., context closing), stop processing.
+    if (!outputChannel) {
+        // console.warn("No output channel available. Stopping.");
+        return false;
     }
 
-    // If noMoreData was set AND we have fully drained the buffer => end
-    if (this.noMoreData && this.buffer.length === 0) {
-      this.port.postMessage({ type: "playback-ended" });
-      console.warn("[PlaybackWorklet] ended after noMoreData + buffer consumed");
-      return false;
+    const blockSize = outputChannel.length; // Number of sample frames needed (typically 128)
+    let samplesCopiedThisCycle = 0;
+
+    // Continue until the output buffer for this cycle is full
+    while (samplesCopiedThisCycle < blockSize) {
+        // Check if we need a new chunk from the queue
+        if (!this.currentChunk || this.currentChunkOffset >= this.currentChunk.length) {
+            if (this.bufferQueue.length > 0) {
+                // Take the next ArrayBuffer and create an Int16Array view
+                const nextBuffer = this.bufferQueue.shift();
+                this.currentChunk = new Int16Array(nextBuffer);
+                this.currentChunkOffset = 0;
+
+                // Signal playback start only once when the first chunk is ready
+                if (!this.playbackStartedSignalled) {
+                    this.port.postMessage({ type: "playback-started" });
+                    this.playbackStartedSignalled = true;
+                }
+            } else {
+                // Buffer queue is empty, and the current chunk (if any) is exhausted.
+                // Fill the rest of the output block with silence for this cycle.
+                for (let i = samplesCopiedThisCycle; i < blockSize; i++) {
+                    outputChannel[i] = 0;
+                }
+                // Increment silence counter *only if* playback had started
+                if(this.playbackStartedSignalled) {
+                    this.silenceFramesCount++;
+                }
+                // Exit the loop for this process() call
+                break;
+            }
+        }
+
+        // Determine how many samples to copy from the current chunk
+        const samplesToCopy = Math.min(
+            blockSize - samplesCopiedThisCycle,         // Remaining space in output buffer
+            this.currentChunk.length - this.currentChunkOffset // Remaining samples in current chunk
+        );
+
+        // Copy and convert samples
+        for (let i = 0; i < samplesToCopy; i++) {
+            outputChannel[samplesCopiedThisCycle + i] = this.currentChunk[this.currentChunkOffset + i] / 32768.0;
+        }
+
+        // Update offsets and counters
+        this.currentChunkOffset += samplesToCopy;
+        samplesCopiedThisCycle += samplesToCopy;
+        this.playedAnyData = true;       // Mark that we've processed actual audio data
+        this.silenceFramesCount = 0;     // Reset silence counter
     }
 
-    // Fallback silence detection logic
-    if (this.framesOfSilence > this.silenceThreshold) {
-      this.port.postMessage({ type: "playback-ended" });
-      console.warn("playback-ended signal detected after silence");
-      this.framesOfSilence = -1; // Reset to avoid sending multiple signals
-      return false;
+    // --- End Condition Checks ---
+    const queueIsEmpty = this.bufferQueue.length === 0;
+    const currentChunkFinished = !this.currentChunk || this.currentChunkOffset >= this.currentChunk.length;
+
+    // Explicit End: 'no-more-data' received, queue empty, current chunk done, and data was played.
+    if (this.noMoreData && queueIsEmpty && currentChunkFinished && this.playedAnyData) {
+        this.port.postMessage({ type: "playback-ended" });
+        this.resetStateAfterEnd(); // Prepare for potential reuse
+        return false; // Stop processing
+    }
+
+    // Implicit End (Silence): Silence threshold exceeded after playback started.
+    if (this.playbackStartedSignalled && this.silenceFramesCount > this.silenceThresholdBlocks) {
+        this.port.postMessage({ type: "playback-ended" });
+        console.warn("playback-ended signal detected after silence");
+        this.resetStateAfterEnd();
+        return false; // Stop processing
     }
     return true;
+  }
+
+  // Resets flags after playback ends, allowing potential reuse without full recreation.
+  resetStateAfterEnd() {
+    this.noMoreData = false;
+    this.playbackStartedSignalled = false;
+    this.playedAnyData = false;
+    this.silenceFramesCount = 0;
   }
 }
 

--- a/modules/playback-worklet.js
+++ b/modules/playback-worklet.js
@@ -2,7 +2,6 @@ class PlaybackWorklet extends AudioWorkletProcessor {
   constructor() {
     super();
     this.port.onmessage = this.handleMessage.bind(this);
-    this.port.on;
     this.buffer = [];
     this.framesOfSilence = -1;    // -1 = haven't started receiving data yet
     this.silenceThreshold = 1000;  // e.g. ~1000 blocks of silence
@@ -15,7 +14,7 @@ class PlaybackWorklet extends AudioWorkletProcessor {
       return;
     }
 
-    if (event.data.type === 'no-more-data') {
+    if (event.data.type === "no-more-data") {
       // The main thread says no more audio chunks will arrive
       this.noMoreData = true;
       return;
@@ -31,7 +30,7 @@ class PlaybackWorklet extends AudioWorkletProcessor {
     // Detect start of audio
     if(this.buffer.length > 0 && this.framesOfSilence === -1) {
       this.framesOfSilence = 0;
-      this.port.postMessage({ type: 'playback-started' });
+      this.port.postMessage({ type: "playback-started" });
     }
     
     // Silence tracker
@@ -54,15 +53,15 @@ class PlaybackWorklet extends AudioWorkletProcessor {
 
     // If noMoreData was set AND we have fully drained the buffer => end
     if (this.noMoreData && this.buffer.length === 0) {
-      this.port.postMessage({ type: 'playback-ended' });
-      console.warn('[PlaybackWorklet] ended after noMoreData + buffer consumed');
+      this.port.postMessage({ type: "playback-ended" });
+      console.warn("[PlaybackWorklet] ended after noMoreData + buffer consumed");
       return false;
     }
 
     // Fallback silence detection logic
     if (this.framesOfSilence > this.silenceThreshold) {
-      this.port.postMessage({ type: 'playback-ended' });
-      console.warn('playback-ended signal detected after silence');
+      this.port.postMessage({ type: "playback-ended" });
+      console.warn("playback-ended signal detected after silence");
       this.framesOfSilence = -1; // Reset to avoid sending multiple signals
       return false;
     }

--- a/modules/talkinghead.mjs
+++ b/modules/talkinghead.mjs
@@ -3407,7 +3407,7 @@ class TalkingHead {
             if ( this.onSubtitles ) {
               this.animQueue.push( {
                 template: { name: 'subtitles' },
-                ts: [time],
+                ts: [audioStart + time],
                 vs: {
                   subtitles: [' ' + word]
                 }

--- a/modules/talkinghead.mjs
+++ b/modules/talkinghead.mjs
@@ -3429,7 +3429,7 @@ class TalkingHead {
                 duration = Math.min( duration, val.visemes.length * 200 );
                 if ( dTotal > 0 ) {
                   for( let j=0; j<val.visemes.length; j++ ) {
-                    const t = time + (val.times[j]/dTotal) * duration;
+                    const t = audioStart + time + (val.times[j]/dTotal) * duration;
                     const d = (val.durations[j]/dTotal) * duration;
                     this.animQueue.push( {
                       template: { name: 'viseme' },


### PR DESCRIPTION
The following improvements were added to the stream audio interface:
1) Improve efficiency by transfering ArrayBuffer object to the audio worklet thread instead of cloning.
2) Fix "Maximum call stack size exceeded" exception and improve efficiency by using a queue for the audio chunks instead of the spread operator.
3) Remove the rudimentary 100ms delay and fix the problem of the lipsync data sent before the first audio chunk. Queue those temporarily and process them once the audio starts playing. 
4) Fix corner cases with the silence detection in the worklet.