### PR TITLE
Fix streamStop() to properly interrupt audio playback

### DIFF
--- a/modules/talkinghead.mjs
+++ b/modules/talkinghead.mjs
@@ -3361,8 +3361,8 @@ class TalkingHead {
   streamStop() {
     if (this.streamWorkletNode) {
       try {
+        this.streamWorkletNode.port.postMessage({type: 'stop'});
         this.streamWorkletNode.disconnect();
-
       } catch(e) { 
         console.error('Error disconnecting streamWorkletNode:', e);
         /* ignore */ 


### PR DESCRIPTION
## Summary

This PR fixes `streamStop()` to properly interrupt audio playback when stopping streaming, ensuring it behaves as documented in Appendix G.

## Problem

Previously, `streamStop()` would disconnect the AudioWorklet but wouldn't immediately stop ongoing audio playback. Buffered audio could continue playing even after the streaming mode was terminated, which contradicted the documented behavior that states it "forces an immediate end to streaming mode."

## Solution

- **Add stop message handling in playback worklet**: Added a `'stop'` message type that immediately clears all buffers (`bufferQueue`, `currentChunk`) and sends a `'playback-ended'` signal
- **Send stop signal before disconnecting**: Modified `streamStop()` to send the stop message to the worklet before disconnecting it
- **Immediate termination**: The worklet now checks for `stopRequested` in the `process()` method and immediately stops processing

## Changes

### `modules/playback-worklet.js`
- Added `stopRequested` flag and `'stop'` message handling
- Clear buffers and reset state when stop is requested
- Check for stop request in `process()` method for immediate termination

### `modules/talkinghead.mjs`  
- Send `'stop'` message to worklet before disconnecting in `streamStop()`

## Testing

The fix ensures that:
1. `streamStop()` immediately stops audio playback as documented
2. No buffered audio continues playing after stream termination
3. The worklet properly cleans up its state
4. The behavior matches the documentation in Appendix G

This change makes the actual behavior consistent with the documented functionality without breaking existing APIs.