### PR TITLE
Improve Streaming Stability and AudioWorklet Reuse + Add Performance Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ This low-level streaming interface is designed for real-time scenarios, such as 
 
 #### API Overview
 
-##### 1. `streamStart(opt={}, onAudioStart, onAudioEnd, onSubtitles)`
+##### 1. `streamStart(opt={}, onAudioStart, onAudioEnd, onSubtitles, onMetrics)`
 
 Enters streaming mode using an `AudioWorklet` for low-latency playback. Parameters:
 
@@ -795,9 +795,11 @@ Enters streaming mode using an `AudioWorklet` for low-latency playback. Paramete
   - `lipsyncLang` – Specifies lip-sync language if you want viseme generation using words. Defaults to avatar `lipsyncLang`, or to options `lipsyncLang` value. 
   - `lipsyncType` – Specifies lip-sync data type. Can take one of the values `visemes` (default), `blendshapes`, and `words`.
   - `mood` – Sets avatar mood upon starting the stream.  
+  - `metrics` – Used for in development performance monitoring: `{enabled: true, intervalHz: 2}`. Enables queue depth and underrun tracking in the audio worklet. Do not set in production.
 - `onAudioStart` *(function, optional)* – Callback invoked the moment audio playback starts.  
 - `onAudioEnd` *(function, optional)* – Callback invoked automatically once audio playback concludes.  
 - `onSubtitles` *(function, optional)* – Callback to handle showing subtitle text.
+- `onMetrics` *(function, optional)* – Callback receiving performance monitoring data: queue depth, underruns, playback state.
 
 Upon calling `streamStart`, all queued speech (`speakText`, `speakAudio`) is stopped, the engine enters streaming mode, and the avatar prepares for real-time lip-sync. You can then feed audio via `streamAudio()`.
 
@@ -816,9 +818,15 @@ Each call to `streamAudio()` schedules an immediate chunk for playback and any i
 
 Signals that no more chunks are expected for the current streaming session. Playback stops automatically once queued audio finishes. This is useful for gracefully concluding real-time TTS streams when your pipeline has no additional data to send.
 
-##### 4. `streamStop()`
+##### 4. `streamStop(disconnect)`
 
-Forces an immediate end to streaming mode, disconnecting the internal `AudioWorklet`. All queued lip-sync animations (visemes, blendshapes) are cleared, and the avatar reverts to its idle state. If needed, you can later re-start streaming via `streamStart()` again.
+Forces an immediate end to streaming mode. All queued lip-sync animations (visemes, blendshapes) are cleared, and the avatar reverts to its idle state. Parameters:
+
+- `disconnect` *(boolean, optional)* – If `true`, also disconnects and cleans up the internal `AudioWorklet`. Use for complete shutdown. Default: `false` (keeps worklet for reuse).
+
+**Usage:**
+- `streamStop()` or `streamStop(false)` – Stop streaming but keep worklet ready for next `streamStart()`
+- `streamStop(true)` – Stop streaming and fully disconnect worklet (for app shutdown or mode switching)
 
 #### Example Usage
 

--- a/examples/azure-audio-streaming.html
+++ b/examples/azure-audio-streaming.html
@@ -51,6 +51,22 @@
       cursor: pointer;
     }
 
+    #stop {
+      width: 80px;
+      height: 100%;
+      font-size: 16px;
+      background: #d32f2f;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      display: none;
+    }
+
+    #stop:hover {
+      background: #b71c1c;
+    }
+
     /* Settings toggle button */
     #settings-button {
       width: 80px;
@@ -143,6 +159,23 @@
       display: inline-block !important;
       width: auto !important;
       margin-right: 0.3rem;
+    }
+
+    /* Small performance HUD */
+    #perfHud {
+      position: absolute;
+      top: 60px;
+      left: 10px;
+      background: rgba(0,0,0,0.5);
+      color: #0f0;
+      font-family: ui-monospace, Menlo, Consolas, monospace;
+      font-size: 12px;
+      padding: 6px 8px;
+      border-radius: 4px;
+      white-space: pre;
+      z-index: 999;
+      min-width: 180px;
+      display: block;
     }
   </style>
 
@@ -272,16 +305,26 @@
     let wordsbuffer = null;
     let azureBlendShapes = null;
     let lipsyncType = "visemes";
-    resetLipsyncBuffers();
+  resetLipsyncBuffers();
 
     document.addEventListener('DOMContentLoaded', async () => {
       console.log("Loading Talking Head...");
       const nodeAvatar = document.getElementById('avatar');
       const nodeSpeak = document.getElementById('speak');
+      const nodeStop = document.getElementById('stop');
       const nodeLoading = document.getElementById('loading');
       const azureRegion = document.getElementById('azure-region');
       const azureTTSKey = document.getElementById('azure-key');
       const settingsButton = document.getElementById('settings-button');
+      const perfHud = document.getElementById('perfHud');
+      const perf = { queuedMs: 0, maxQueuedMs: 0, underruns: 0, state: 'idle' };
+      function updateHUD() {
+        perfHud.textContent =
+          `Audio worklet\n`+
+          `state: ${perf.state}\n`+
+          `queued: ${perf.queuedMs|0} ms (max ${perf.maxQueuedMs|0} ms)\n`+
+          `underruns: ${perf.underruns}`;
+      }
 
       azureTTSKey.value = sessionStorage.getItem('azureTTSKey') || '';
       azureRegion.value = sessionStorage.getItem('azureRegion') || '';
@@ -331,6 +374,16 @@
         if (text) {
           const ssml = textToSSML(text);
           azureSpeak(ssml);
+        }
+      });
+
+      // Handle stop button click
+      nodeStop.addEventListener('click', () => {
+        if (head.isStreaming) {
+          head.streamStop();
+          nodeStop.style.display = 'none';
+          nodeSpeak.disabled = false;
+          console.log("Streaming stopped by user.");
         }
       });
 
@@ -464,12 +517,24 @@
 
         // Start stream speaking
         head.streamStart(
-          { sampleRate: 48000, mood: "happy", gain: 0.5, lipsyncType: lipsyncType },
+          { 
+            sampleRate: 48000, 
+            mood: "happy", 
+            gain: 0.5, 
+            lipsyncType: lipsyncType,
+            // Configure metrics: enabled, reporting rate
+            metrics: { enabled: true, intervalHz: 2 }
+          },
           () => {
             console.log("Audio playback started.");
             const subtitlesElement = document.getElementById("subtitles");
             subtitlesElement.textContent = "";
             subtitlesElement.style.display = "none";
+            perf.state = 'playing';
+            updateHUD();
+            // Show stop button, disable speak button
+            nodeStop.style.display = 'block';
+            nodeSpeak.disabled = true;
           },
           () => {
             console.log("Audio playback ended.");
@@ -479,12 +544,30 @@
               subtitlesElement.textContent = "";
               subtitlesElement.style.display = "none";
             }, displayDuration);
+            // Keep HUD visible, switch to idle state showing last metrics
+            perf.state = 'idle';
+            updateHUD();
+            // Hide stop button, enable speak button
+            nodeStop.style.display = 'none';
+            nodeSpeak.disabled = false;
           },
           (subtitleText) => {
             console.log("subtitleText: ", subtitleText);
             const subtitlesElement = document.getElementById("subtitles");
             subtitlesElement.textContent += subtitleText;
             subtitlesElement.style.display = subtitlesElement.textContent ? "block" : "none";
+          },
+          // onMetrics
+          (ev) => {
+            if (!ev) return;
+            if (ev.type === 'metrics' && ev.data) {
+              const m = ev.data;
+              perf.queuedMs = m.queuedMs;
+              perf.maxQueuedMs = m.maxQueuedMs;
+              perf.underruns = m.underrunBlocks;
+              perf.state = (m.state === 1) ? 'playing' : 'idle';
+              updateHUD();
+            }
           }
         );
 
@@ -549,11 +632,13 @@
   <!-- 3D Avatar -->
   <div id="avatar"></div>
   <div id="subtitles"></div>
+  <div id="perfHud"></div>
 
   <!-- Controls at the top -->
   <div id="controls">
     <input id="text" type="text" value="Hello, how are you?" />
     <button id="speak">Speak</button>
+    <button id="stop">Stop</button>
     <button id="settings-button">Settings</button>
   </div>
 

--- a/modules/talkinghead.mjs
+++ b/modules/talkinghead.mjs
@@ -1252,7 +1252,7 @@ class TalkingHead {
       // Copy previous values
       const y = this.mtAvatar[x];
       if ( y ) {
-        [ 'fixed','system','systemd','base','v','value','applied' ].forEach( z => {
+        [ 'fixed','system','systemd','realtime','base','v','value','applied' ].forEach( z => {
           mtTemp[x][z] = y[z];
         });
       }


### PR DESCRIPTION
### Summary

This PR includes a significant refactor and a set of improvements to the streaming functionality, aiming to enhance stability, performance, and developer ergonomics.

### Key Changes

#### ✅ Fix stream interruption issues

* Addresses cases where ongoing streaming could stop unexpectedly or hang.

#### 🔄 Improve audio worklet reuse

* In conversation scenarios, the audio worklet is now reused across turns instead of being recreated each time.
* This reduces setup overhead and improves latency.

#### 📘 Updated streaming flow (with reuse support):

**🔹 First turn in a conversation**

* `streamStart` (first-time call): Initializes and sets up the audio worklet.
* Multiple `streamAudio` calls: Sends audio and lipsync data.
* `streamNotifyEnd`: Marks the end of the stream and allows the avatar to transition to idle.
  *Note: `streamStop` is **not** needed here.*

**🔹 Subsequent turns in the conversation**

* `streamStart` is optional; only needed if audio configurations change.
* Multiple `streamAudio` calls.
* `streamNotifyEnd`: Ends the stream naturally.

**🔹 Interrupted turn**

* `streamStart` is optional.
* `streamAudio` calls as usual.
* `streamNotifyEnd` is called, followed by:
* `streamStop`: Used to forcefully stop streaming and clear buffers.
  *The audio worklet remains reusable.*

**🔹 Conversation or application end**

* Call `streamStop(true)` to fully disconnect and delete the audio worklet.

#### 📊 Add optional performance metrics

* Introduced internal metrics to help track and debug streaming performance.
* Disabled by default; can be enabled for testing.

#### ⚙️ Optimize audio worklet logic

* Removed redundant buffering and unnecessary loop logic.
* Simplified internal state management for better performance and maintainability.

